### PR TITLE
Catch Test Failures in Web CI

### DIFF
--- a/.github/workflows/Web.yaml
+++ b/.github/workflows/Web.yaml
@@ -44,4 +44,11 @@ jobs:
       shell: bash
       run: |
         set -x
-        node .Construction/JavaScript/Package.js
+        node .Construction/JavaScript/Package.js 2>Errors
+        if [ $? -eq 0 -a ! -s Errors ]
+        then
+          echo "Succeeded."
+        else
+          cat Errors
+          exit 1
+        fi


### PR DESCRIPTION
Node does not fail on `console.assert`. Until a better implementation of `verify ()` exists; CI must check for anything written to standard error.